### PR TITLE
the nhs number exists before the hospital number in results, so just …

### DIFF
--- a/gloss/api/templates/send_hl7.html
+++ b/gloss/api/templates/send_hl7.html
@@ -11,7 +11,7 @@
         <h1>HL7 Impersonator</h1>
       </div>
       <div>
-        <input type="text", data-bind="value: hospitalNumber"></input>
+        <input type="text", data-bind="value: hospitalNumber, valueUpdate: 'keyup'"></input>
       </div>
       <div class="row">
         <label for="messageTypeSelector">select a message type</label>
@@ -60,7 +60,7 @@
 
           _.each(raw_messages, function(x, i){
               if(x.startsWith(("PID"))){
-                  raw_messages[i] = x.replace(oldValue, newValue);
+                  raw_messages[i] = x.split(oldValue).join(newValue);
               }
           });
 


### PR DESCRIPTION
…change all numbers

you were right, nhs numbers come before hospital numbers in the result, which was why they didn't look right. My quick fix is to just change all numbers, that way at least what you see in elcid is going to look the same as what you see in the hl7 send window.

Maybe I should have just gone with the input box around the template...
